### PR TITLE
feat: divider 컴포넌트

### DIFF
--- a/src/components/common/Divder/index.stories.tsx
+++ b/src/components/common/Divder/index.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, Story } from '@storybook/react';
+import Divider from '@/components/common/Divder';
+
+export default {
+  component: Divider,
+} as Meta<typeof Divider>;
+
+export const Row = {
+  args: {},
+
+  name: 'row',
+};
+
+export const col = {
+  args: {
+    direction: 'col',
+  },
+  decorators: [
+    (Story: Story) => (
+      <div style={{ width: '500px', height: '500px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+
+  name: 'col',
+};

--- a/src/components/common/Divder/index.tsx
+++ b/src/components/common/Divder/index.tsx
@@ -1,0 +1,14 @@
+import * as Styled from './style';
+
+export interface DividerProps {
+  percent?: number;
+  direction?: 'row' | 'col';
+  className?: string;
+}
+
+const Divider = (props: DividerProps) => {
+  const { percent = 100, direction = 'row', className, ...rest } = props;
+  return <Styled.Divider css={Styled.getDirectionStyles({ percent, direction })} className={className} {...rest} />;
+};
+
+export default Divider;

--- a/src/components/common/Divder/style.ts
+++ b/src/components/common/Divder/style.ts
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+import type { DividerProps } from '@/components/common/Divder';
+import type { EmotionTheme } from '@/styles/emotion';
+
+type StyledDividerProps = Required<Pick<DividerProps, 'percent' | 'direction'>>;
+
+export const getDirectionStyles = (props: StyledDividerProps) => {
+  const { percent, direction } = props;
+
+  const directStyles = {
+    row: (theme: EmotionTheme) => css`
+      border-bottom: 1px solid ${theme.colors.gray_500};
+      width: ${percent}%;
+    `,
+    col: (theme: EmotionTheme) => css`
+      border-left: 1px solid ${theme.colors.gray_500};
+      width: 1px;
+      height: ${percent}%;
+    `,
+  };
+
+  return directStyles[direction];
+};
+
+export const Divider = styled.div``;


### PR DESCRIPTION
## 변경사항

[스토리북](https://6513e523ff3743561f1e3e49-igyzaalndd.chromatic.com/?path=/story/components-common-divder--row)

divider의 너비, 높이를 percent 라는 number props로 조정할 수 있도록 했습니다.

## 체크리스트

-   [x] divider 구현
-   [x] divider 스토리북

## Linked Issues

close #24 