### PR TITLE
feat: [공통 컴포넌트] 토스트 메시지 구현

### DIFF
--- a/src/components/common/Portal/index.tsx
+++ b/src/components/common/Portal/index.tsx
@@ -1,0 +1,32 @@
+import type { PropsWithChildren } from 'react';
+import { useEffect, useId, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  portalId?: string;
+}
+const Portal = (props: PropsWithChildren<PortalProps>) => {
+  const { portalId, children } = props;
+
+  const [element, setElement] = useState<HTMLElement | null>(null);
+  const id = useId();
+  const elementId = portalId ?? `$portal-${id}`;
+
+  useEffect(() => {
+    let modalRoot = document.getElementById(elementId);
+    if (!modalRoot) {
+      modalRoot = document.createElement('div');
+      modalRoot.setAttribute('id', elementId);
+      document.body.appendChild(modalRoot);
+    }
+    setElement(modalRoot);
+  }, [elementId]);
+
+  if (!element) {
+    return null;
+  }
+
+  return createPortal(children, element);
+};
+
+export default Portal;

--- a/src/components/common/Toast/index.tsx
+++ b/src/components/common/Toast/index.tsx
@@ -1,0 +1,13 @@
+import * as Styled from './style';
+
+export interface ToastProps {
+  message: string;
+}
+
+const Toast = (props: ToastProps) => {
+  const { message } = props;
+
+  return <Styled.Root>{message}</Styled.Root>;
+};
+
+export default Toast;

--- a/src/components/common/Toast/provider/index.tsx
+++ b/src/components/common/Toast/provider/index.tsx
@@ -1,0 +1,60 @@
+import type { PropsWithChildren } from 'react';
+import { createContext, useState } from 'react';
+import Portal from '@/components/common/Portal';
+import Toast from '@/components/common/Toast';
+import { useTimeout } from '@/components/common/Toast/useTimeout';
+import * as Styled from './style';
+
+export interface ToastOption {
+  message: string;
+}
+
+export interface ToastController {
+  show: (option: ToastOption) => void;
+}
+
+export const ToastContext = createContext<ToastController>({} as ToastController);
+
+export interface ToastProviderProps {
+  duration?: number;
+}
+
+const ToastProvider = (props: PropsWithChildren<ToastProviderProps>) => {
+  const { duration = 1500, children } = props;
+
+  const [toast, setToast] = useState<ToastOption | null>(null);
+  const [animation, setAnimation] = useState<'slide-in' | 'slide-out' | 'slide-reset'>('slide-in');
+  const toastTimeout = useTimeout();
+
+  const controller: ToastController = {
+    show: async ({ message }: ToastOption) => {
+      setToast({ message });
+      setAnimation('slide-reset');
+
+      // 연속 클릭시 slide-reset이 실행된 후 slide-in이 실행되도록 함.
+      await sleep(0);
+
+      setAnimation('slide-in');
+      toastTimeout.set(() => {
+        setAnimation('slide-out');
+      }, duration);
+    },
+  };
+
+  return (
+    <ToastContext.Provider value={controller}>
+      {children}
+      <Portal>
+        <Styled.ToastContainer animation={animation}>
+          {toast && <Toast message={toast.message} />}
+        </Styled.ToastContainer>
+      </Portal>
+    </ToastContext.Provider>
+  );
+};
+
+export default ToastProvider;
+
+const sleep = (delay: number) => {
+  return new Promise((resolve) => setTimeout(resolve, delay));
+};

--- a/src/components/common/Toast/provider/style.ts
+++ b/src/components/common/Toast/provider/style.ts
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+
+export const ToastContainer = styled.div<{ animation: string }>`
+  display: flex;
+  justify-content: center;
+  position: fixed;
+  bottom: 50px;
+  left: 0px;
+  transform: translateY(300%);
+  width: 100%;
+  z-index: 100;
+  // fowards 애니메이션의 마지막 상태를 유지
+  animation: 0.3s forwards ${(props) => props.animation};
+
+  @keyframes slide-in {
+    from {
+      transform: translateY(300%);
+    }
+
+    to {
+      transform: translateY(0%);
+    }
+  }
+
+  @keyframes slide-out {
+    from {
+      transform: translateY(0%);
+    }
+
+    to {
+      transform: translateY(300%);
+    }
+  }
+
+  @keyframes slide-reset {
+    from {
+      transform: translateY(300%);
+    }
+
+    to {
+      transform: translateY(300%);
+    }
+  }
+`;

--- a/src/components/common/Toast/style.ts
+++ b/src/components/common/Toast/style.ts
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+export const Root = styled.div`
+  width: 50%;
+  padding: 1.25rem;
+  border-radius: 6px;
+  border: 1px solid #e4e4e7;
+  background-color: #09090b;
+  color: #fff;
+  box-shadow:
+    0px 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0px 4px 6px -4px rgba(16, 24, 40, 0.1);
+`;

--- a/src/components/common/Toast/useTimeout.ts
+++ b/src/components/common/Toast/useTimeout.ts
@@ -1,0 +1,16 @@
+import { useRef } from 'react';
+
+type TimeoutID = ReturnType<typeof setTimeout>;
+
+export const useTimeout = () => {
+  const timeoutRef = useRef<TimeoutID | null>(null);
+
+  return {
+    set(handler: () => void, duration: number) {
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(handler, duration);
+    },
+  };
+};

--- a/src/components/common/Toast/useToast.ts
+++ b/src/components/common/Toast/useToast.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { ToastContext } from '@/components/common/Toast/provider';
+import type { ToastOption } from '@/components/common/Toast/provider';
+
+export const useToast = () => {
+  const controller = useContext(ToastContext);
+
+  return {
+    show(toast: ToastOption) {
+      controller.show(toast);
+    },
+  };
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { AppProps } from 'next/app';
 import { ThemeProvider } from '@emotion/react';
+import ToastProvider from '@/components/common/Toast/provider';
 import { emotionTheme } from '@/styles/emotion';
 import '@/styles/globals.css';
 
@@ -20,7 +21,9 @@ if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider theme={emotionTheme}>
-      <Component {...pageProps} />
+      <ToastProvider>
+        <Component {...pageProps} />
+      </ToastProvider>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## 변경사항

모달 만들다 토스트 메세지 만드는게 재밌어보여 이것부터 만들었습니다..

### 토스트 메세지 구현
스토리북으로 하려다 ToastProvider 가 스토리북의 main.ts에 잘 적용이 안되어 동영상으로 찍어놨습니다.

https://github.com/Step3-kakao-tech-campus/Team7_FE/assets/62373865/e30d894e-82bd-4016-9fe7-8251efaa3e1a


사용방법은 다음과 같습니다. useToast 훅에서 toast 객체를 꺼내 show 를 호출하면 됩니다. 

```
import { useToast } from '@/components/common/Toast/useToast';

export default function Home() {
  const toast = useToast();

  return (
    <button
      onClick={() => {
        toast.show({
          message: '로그인 후 사용해주세요.',
        });
      }}>
      홈
    </button>
  );
}
```

### Portal 사용이유

Portal 을 사용하면 id="__next" 가 아닌 다른 id 를 가진 DOM에 토스트 UI가 만들어집니다. 따라서 z-index 와 같은 값만 고려해주면 최상위에 토스트를 쉽게 띄울 수 있습니다.

만약에 포탈을 사용하지 않는다면 https://codesandbox.io/s/x8sq6l?file=%2FApp.js&utm_medium=sandpack 
참고 링크와 같이 특정 컴포넌트의 방해로 UI 에 영향을 줄 수 도 있고 이를 막기위해서 최상위 컴포넌트에 토스트 메세지를 생성해야하는데 이는 isOpen과 같은 state 핸들러의 드릴링을 유발합니다. 

따라서 Portal 을 사용하는 것이 좋다고 생각하여 적용했습니다.


## 체크리스트

-   [x] Toast 구현
-   [ ] Toast 스토리북


## Linked Issues

close #29 