### PR TITLE
feat: [공통 컴포넌트] 모달 컴포넌트 

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "next": "13.5.2",
     "react": "18.2.0",
     "react-datepicker": "^4.18.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-remove-scroll": "^2.5.6"
   },
   "devDependencies": {
     "@emotion/babel-preset-css-prop": "^11.11.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query": "^4.35.3",
     "axios": "^1.5.0",
     "dayjs": "^1.11.10",
+    "focus-trap-react": "^10.2.2",
     "next": "13.5.2",
     "react": "18.2.0",
     "react-datepicker": "^4.18.0",

--- a/public/assets/icons/ic_closeButton.svg
+++ b/public/assets/icons/ic_closeButton.svg
@@ -1,0 +1,4 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect width="32" height="32" rx="16" fill="#E5E5E5"/>
+<path d="M16 14.6669L20.6669 10L22 11.3331L17.3331 16L22 20.6669L20.6669 22L16 17.3331L11.3331 22L10 20.6669L14.6669 16L10 11.3331L11.3331 10L16 14.6669Z" fill="#4F4F4F"/>
+</svg>

--- a/src/components/common/Modal/index.stories.tsx
+++ b/src/components/common/Modal/index.stories.tsx
@@ -8,6 +8,17 @@ export default {
   component: Modal,
 } as Meta<typeof Modal>;
 
+export const Default = () => {
+  const { isOpen, handleOpen, handleClose } = useModalState();
+
+  return (
+    <>
+      <button onClick={handleOpen}>클릭하여 모달 열기</button>
+      <Modal title="모달 예시" isOpen={isOpen} onClose={handleClose} />
+    </>
+  );
+};
+
 export const WithState = () => {
   const { isOpen, handleOpen, handleClose } = useModalState();
 

--- a/src/components/common/Modal/index.stories.tsx
+++ b/src/components/common/Modal/index.stories.tsx
@@ -1,0 +1,67 @@
+import styled from '@emotion/styled';
+import type { Meta } from '@storybook/react';
+import Button from '@/components/common/Button';
+import Modal from '@/components/common/Modal';
+import { useModalState } from '@/components/common/Modal/useModalState';
+
+export default {
+  component: Modal,
+} as Meta<typeof Modal>;
+
+export const WithState = () => {
+  const { isOpen, handleOpen, handleClose } = useModalState();
+
+  const handleSubmit = () => {
+    /* 대충 서버에 제출하는 로직 */
+
+    handleClose();
+  };
+
+  return (
+    <>
+      <button onClick={handleOpen}>클릭하여 모달 열기</button>
+      <Modal title="모달 예시" isOpen={isOpen} onClose={handleClose}>
+        <Title>TIL 제출하기</Title>
+        <Info>
+          <InfoText>그룹 로드맵 제출은 한번만 가능합니다</InfoText>
+          <InfoText>그래도 제출하시겠습니까?</InfoText>
+        </Info>
+        <ButtonContainer>
+          <Button variant="ghost" onClick={handleClose}>
+            취소
+          </Button>
+          <Button onClick={handleSubmit}>확인</Button>
+        </ButtonContainer>
+      </Modal>
+    </>
+  );
+};
+
+const Title = styled.h3`
+  font-size: 26px;
+  font-weight: 700;
+  line-height: 1.5;
+`;
+
+const Info = styled.p`
+  margin-top: 0.8rem;
+  padding: 0.6em;
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.colors.blue_gray_200};
+  border-radius: 0.3rem;
+  background-color: ${({ theme }) => theme.colors.gray_100};
+  list-style-type: disc;
+  list-style-position: inside;
+`;
+
+const InfoText = styled.li`
+  margin: 0.5rem 0.4rem;
+  font-size: 1rem;
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  justify-content: flex-end;
+
+  margin-top: 1.3rem;
+`;

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -1,0 +1,46 @@
+import FocusTrap from 'focus-trap-react';
+import { type PropsWithChildren, type HTMLAttributes, useRef } from 'react';
+import { RemoveScroll } from 'react-remove-scroll';
+import Image from 'next/image';
+import Portal from '@/components/common/Portal';
+import { useOnClickOutside } from '@/hooks/useOnClickOutside';
+import * as Styled from './style';
+
+export interface ModalProps extends HTMLAttributes<HTMLDivElement> {
+  width?: number;
+  isOpen?: boolean;
+  onClose: () => void;
+}
+
+const Modal = (props: PropsWithChildren<ModalProps>) => {
+  const { children, width, isOpen, onClose, ...rest } = props;
+
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useOnClickOutside(modalRef, () => {
+    onClose();
+  });
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Portal>
+      <Styled.Background>
+        <FocusTrap>
+          <RemoveScroll>
+            <Styled.Container role="dialog" ref={modalRef} width={width} {...rest}>
+              <Styled.CloseButton onClick={onClose}>
+                <Image src="/assets/icons/ic_closeButton.svg" alt="close" width={24} height={24} />
+              </Styled.CloseButton>
+              <Styled.Content>{children}</Styled.Content>
+            </Styled.Container>
+          </RemoveScroll>
+        </FocusTrap>
+      </Styled.Background>
+    </Portal>
+  );
+};
+
+export default Modal;

--- a/src/components/common/Modal/style.ts
+++ b/src/components/common/Modal/style.ts
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+
+export const Background = styled.div`
+  display: flex;
+  position: fixed;
+  top: 0;
+  left: 0;
+  align-items: center;
+  justify-content: center;
+  z-index: 99999;
+  background-color: rgb(0 0 0 / 70%);
+  width: 100%;
+  height: 100%;
+`;
+
+export const Container = styled.div<{ width?: number }>`
+  position: relative;
+  z-index: 101;
+  border-radius: 20px;
+  background: #fff;
+  width: ${({ width }) => width ?? 28}rem;
+  color: ${({ theme }) => theme.colors.black};
+  box-shadow:
+    0px 4px 6px -4px rgba(0, 0, 0, 0.1),
+    0px 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0px 0px 0px 1px rgba(0, 0, 0, 0.1);
+`;
+
+export const CloseButton = styled.button`
+  display: flex;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  padding: 0.25rem;
+`;
+
+export const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 2rem 2.5rem;
+`;

--- a/src/components/common/Modal/style.ts
+++ b/src/components/common/Modal/style.ts
@@ -24,6 +24,10 @@ export const Container = styled.div<{ width?: number }>`
     0px 4px 6px -4px rgba(0, 0, 0, 0.1),
     0px 10px 15px -3px rgba(0, 0, 0, 0.1),
     0px 0px 0px 1px rgba(0, 0, 0, 0.1);
+
+  & :focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.black};
+  }
 `;
 
 export const CloseButton = styled.button`

--- a/src/components/common/Modal/style.ts
+++ b/src/components/common/Modal/style.ts
@@ -44,5 +44,5 @@ export const CloseButton = styled.button`
 export const Content = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 2rem 2.5rem;
+  padding: 2rem 2.5rem 1.6rem;
 `;

--- a/src/components/common/Modal/useModalState.ts
+++ b/src/components/common/Modal/useModalState.ts
@@ -1,0 +1,14 @@
+import { useState } from 'react';
+
+export const useModalState = (initialState = false) => {
+  const [isOpen, setIsOpen] = useState<boolean>(initialState);
+
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+  const handleClose = () => {
+    setIsOpen(false);
+  };
+
+  return { isOpen, handleOpen, handleClose };
+};

--- a/src/components/common/Portal/index.tsx
+++ b/src/components/common/Portal/index.tsx
@@ -1,0 +1,32 @@
+import type { PropsWithChildren } from 'react';
+import { useEffect, useId, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  portalId?: string;
+}
+const Portal = (props: PropsWithChildren<PortalProps>) => {
+  const { portalId, children } = props;
+
+  const [element, setElement] = useState<HTMLElement | null>(null);
+  const id = useId();
+  const elementId = portalId ?? `$portal-${id}`;
+
+  useEffect(() => {
+    let modalRoot = document.getElementById(elementId);
+    if (!modalRoot) {
+      modalRoot = document.createElement('div');
+      modalRoot.setAttribute('id', elementId);
+      document.body.appendChild(modalRoot);
+    }
+    setElement(modalRoot);
+  }, [elementId]);
+
+  if (!element) {
+    return null;
+  }
+
+  return createPortal(children, element);
+};
+
+export default Portal;

--- a/src/components/common/Portal/index.tsx
+++ b/src/components/common/Portal/index.tsx
@@ -13,13 +13,13 @@ const Portal = (props: PropsWithChildren<PortalProps>) => {
   const elementId = portalId ?? `$portal-${id}`;
 
   useEffect(() => {
-    let modalRoot = document.getElementById(elementId);
-    if (!modalRoot) {
-      modalRoot = document.createElement('div');
-      modalRoot.setAttribute('id', elementId);
-      document.body.appendChild(modalRoot);
+    let Root = document.getElementById(elementId);
+    if (!Root) {
+      Root = document.createElement('div');
+      Root.setAttribute('id', elementId);
+      document.body.appendChild(Root);
     }
-    setElement(modalRoot);
+    setElement(Root);
   }, [elementId]);
 
   if (!element) {

--- a/src/components/common/Toast/index.tsx
+++ b/src/components/common/Toast/index.tsx
@@ -1,0 +1,13 @@
+import * as Styled from './style';
+
+export interface ToastProps {
+  message: string;
+}
+
+const Toast = (props: ToastProps) => {
+  const { message } = props;
+
+  return <Styled.Root>{message}</Styled.Root>;
+};
+
+export default Toast;

--- a/src/components/common/Toast/provider/index.tsx
+++ b/src/components/common/Toast/provider/index.tsx
@@ -1,0 +1,60 @@
+import type { PropsWithChildren } from 'react';
+import { createContext, useState } from 'react';
+import Portal from '@/components/common/Portal';
+import Toast from '@/components/common/Toast';
+import { useTimeout } from '@/components/common/Toast/useTimeout';
+import * as Styled from './style';
+
+export interface ToastOption {
+  message: string;
+}
+
+export interface ToastController {
+  show: (option: ToastOption) => void;
+}
+
+export const ToastContext = createContext<ToastController>({} as ToastController);
+
+export interface ToastProviderProps {
+  duration?: number;
+}
+
+const ToastProvider = (props: PropsWithChildren<ToastProviderProps>) => {
+  const { duration = 1500, children } = props;
+
+  const [toast, setToast] = useState<ToastOption | null>(null);
+  const [animation, setAnimation] = useState<'slide-in' | 'slide-out' | 'slide-reset'>('slide-in');
+  const toastTimeout = useTimeout();
+
+  const controller: ToastController = {
+    show: async ({ message }: ToastOption) => {
+      setToast({ message });
+      setAnimation('slide-reset');
+
+      // 연속 클릭시 slide-reset이 실행된 후 slide-in이 실행되도록 함.
+      await sleep(0);
+
+      setAnimation('slide-in');
+      toastTimeout.set(() => {
+        setAnimation('slide-out');
+      }, duration);
+    },
+  };
+
+  return (
+    <ToastContext.Provider value={controller}>
+      {children}
+      <Portal>
+        <Styled.ToastContainer animation={animation}>
+          {toast && <Toast message={toast.message} />}
+        </Styled.ToastContainer>
+      </Portal>
+    </ToastContext.Provider>
+  );
+};
+
+export default ToastProvider;
+
+const sleep = (delay: number) => {
+  return new Promise((resolve) => setTimeout(resolve, delay));
+};

--- a/src/components/common/Toast/provider/style.ts
+++ b/src/components/common/Toast/provider/style.ts
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+
+export const ToastContainer = styled.div<{ animation: string }>`
+  display: flex;
+  justify-content: center;
+  position: fixed;
+  bottom: 50px;
+  left: 0px;
+  transform: translateY(300%);
+  width: 100%;
+  z-index: 100;
+  // fowards 애니메이션의 마지막 상태를 유지
+  animation: 0.3s forwards ${(props) => props.animation};
+
+  @keyframes slide-in {
+    from {
+      transform: translateY(300%);
+    }
+
+    to {
+      transform: translateY(0%);
+    }
+  }
+
+  @keyframes slide-out {
+    from {
+      transform: translateY(0%);
+    }
+
+    to {
+      transform: translateY(300%);
+    }
+  }
+
+  @keyframes slide-reset {
+    from {
+      transform: translateY(300%);
+    }
+
+    to {
+      transform: translateY(300%);
+    }
+  }
+`;

--- a/src/components/common/Toast/style.ts
+++ b/src/components/common/Toast/style.ts
@@ -1,0 +1,13 @@
+import styled from '@emotion/styled';
+
+export const Root = styled.div`
+  width: 50%;
+  padding: 1.25rem;
+  border-radius: 6px;
+  border: 1px solid #e4e4e7;
+  background-color: #09090b;
+  color: #fff;
+  box-shadow:
+    0px 10px 15px -3px rgba(0, 0, 0, 0.1),
+    0px 4px 6px -4px rgba(16, 24, 40, 0.1);
+`;

--- a/src/components/common/Toast/useTimeout.ts
+++ b/src/components/common/Toast/useTimeout.ts
@@ -1,0 +1,16 @@
+import { useRef } from 'react';
+
+type TimeoutID = ReturnType<typeof setTimeout>;
+
+export const useTimeout = () => {
+  const timeoutRef = useRef<TimeoutID | null>(null);
+
+  return {
+    set(handler: () => void, duration: number) {
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+      }
+      timeoutRef.current = setTimeout(handler, duration);
+    },
+  };
+};

--- a/src/components/common/Toast/useToast.ts
+++ b/src/components/common/Toast/useToast.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { ToastContext } from '@/components/common/Toast/provider';
+import type { ToastOption } from '@/components/common/Toast/provider';
+
+export const useToast = () => {
+  const controller = useContext(ToastContext);
+
+  return {
+    show(toast: ToastOption) {
+      controller.show(toast);
+    },
+  };
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import type { AppProps } from 'next/app';
 import { ThemeProvider } from '@emotion/react';
+import ToastProvider from '@/components/common/Toast/provider';
 import { emotionTheme } from '@/styles/emotion';
 import '@/styles/globals.css';
 
@@ -20,7 +21,9 @@ if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <ThemeProvider theme={emotionTheme}>
-      <Component {...pageProps} />
+      <ToastProvider>
+        <Component {...pageProps} />
+      </ToastProvider>
     </ThemeProvider>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8893,7 +8893,7 @@ react-refresh@^0.11.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
 
-react-remove-scroll-bar@^2.3.3:
+react-remove-scroll-bar@^2.3.3, react-remove-scroll-bar@^2.3.4:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz#53e272d7a5cb8242990c7f144c44d8bd8ab5afd9"
   integrity sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==
@@ -8907,6 +8907,17 @@ react-remove-scroll@2.5.5:
   integrity sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==
   dependencies:
     react-remove-scroll-bar "^2.3.3"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
+react-remove-scroll@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.5.6.tgz#7510b8079e9c7eebe00e65a33daaa3aa29a10336"
+  integrity sha512-bO856ad1uDYLefgArk559IzUNeQ6SWH4QnrevIUjH+GczV56giDfl3h0Idptf2oIKxQmd1p9BN25jleKodTALg==
+  dependencies:
+    react-remove-scroll-bar "^2.3.4"
     react-style-singleton "^2.2.1"
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6236,6 +6236,21 @@ flow-parser@0.*:
   resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.217.0.tgz#0e6bed214151fa3240dc9fd83ac8a9e050e523c5"
   integrity sha512-hEa5n0dta1RcaDwJDWbnyelw07PK7+Vx0f9kDht28JOt2hXgKdKGaT3wM45euWV2DxOXtzDSTaUgGSD/FPvC2Q==
 
+focus-trap-react@^10.2.2:
+  version "10.2.2"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-10.2.2.tgz#3b57cdee506e16c3cb75d2cb939b2d509b450489"
+  integrity sha512-ktfVCuRyT2fikb1De8u5bs3afdqFTJu6Hl1iGThwmo++k2+/n78DapitplvHGZ0hkDPlyHvAWGQsR74KF30zxw==
+  dependencies:
+    focus-trap "^7.5.3"
+    tabbable "^6.2.0"
+
+focus-trap@^7.5.3:
+  version "7.5.3"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.5.3.tgz#fbb39af6ef2e19aa10707e28583fdccf91a4243d"
+  integrity sha512-7UsT/eSJcTPF0aZp73u7hBRTABz26knRRTJfoTGFCQD5mUImLIIOwWWCrtoQdmWa7dykBi6H+Cp5i3S/kvsMeA==
+  dependencies:
+    tabbable "^6.2.0"
+
 follow-redirects@^1.15.0:
   version "1.15.3"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.3.tgz#fe2f3ef2690afce7e82ed0b44db08165b207123a"
@@ -9766,6 +9781,11 @@ synckit@^0.8.5:
   dependencies:
     "@pkgr/utils" "^2.3.1"
     tslib "^2.5.0"
+
+tabbable@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-6.2.0.tgz#732fb62bc0175cfcec257330be187dcfba1f3b97"
+  integrity sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==
 
 tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0, tapable@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
## 변경사항
[스토리북](https://6513e523ff3743561f1e3e49-xbdojrmucy.chromatic.com/?path=/story/components-common-modal--default)

1. focus-trap-react 라이브러리 설치
modal이 켜졌을때 tab으로 해당 모달 버튼, input 요소에만 focus가 되도록 하기위해 설치했습니다.

2. react-remove-scroll 라이브러리 설치
모달이 켜졌을때 배경 부분이 스크롤 되지 않기위해 사용했습니다.

3. 모달 추상화
와이어프레임에 모달이 많은데 최대한 공통적으로 사용될 부분만 추상화 해놓았습니다. 
각각 모달의 세부구현은 해당 공통 모달을 사용하여 구현하면 될 것 같습니다.

## 체크리스트

- [x] 모달 컴포넌트 구현
- [x] 모달 컴포넌트 스토리북

## Linked Issues

close #26 