### PR TITLE
feat: 토큰을 통한 로그인 상태 관리

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.47.0",
     "react-remove-scroll": "^2.5.6",
-    "react-resizable-panels": "^0.0.55"
+    "react-resizable-panels": "^0.0.55",
+    "recoil": "^0.7.7"
   },
   "devDependencies": {
     "@emotion/babel-preset-css-prop": "^11.11.0",

--- a/src/api/auth/type.ts
+++ b/src/api/auth/type.ts
@@ -44,5 +44,5 @@ export interface LoginResponse {
   success: boolean;
   code: number;
   message: string;
-  result: null;
+  result: { token: string } | null;
 }

--- a/src/components/auth/login/index.tsx
+++ b/src/components/auth/login/index.tsx
@@ -1,3 +1,4 @@
+import { useSetRecoilState } from 'recoil';
 import { useForm, Controller, type SubmitHandler } from 'react-hook-form';
 import { useRouter } from 'next/router';
 import { useMutation } from '@tanstack/react-query';
@@ -8,6 +9,7 @@ import Flex from '@/components/common/Flex';
 import Input from '@/components/common/Input';
 import Logo from '@/components/common/Logo';
 import { tilyLinks } from '@/constants/links';
+import { accessTokenAtom } from '../states/accessTokenAtoms';
 
 interface LoginFormInput {
   email: string;
@@ -16,6 +18,8 @@ interface LoginFormInput {
 
 const Login = () => {
   const { mutateAsync, isLoading } = useMutation({ mutationFn: (data: LoginFormInput) => postLogin(data) });
+
+  const setAccessToken = useSetRecoilState(accessTokenAtom);
 
   const router = useRouter();
 
@@ -34,7 +38,8 @@ const Login = () => {
   const onSubmit: SubmitHandler<LoginFormInput> = async (formData) => {
     const data = await mutateAsync(formData);
 
-    if (data?.code === 200) {
+    if (data?.code === 200 && data?.result?.token) {
+      setAccessToken(data?.result?.token);
       router.replace(tilyLinks.home());
     } else {
       // 에러 처리

--- a/src/components/auth/states/accessTokenAtoms.ts
+++ b/src/components/auth/states/accessTokenAtoms.ts
@@ -1,4 +1,5 @@
 import { atom } from 'recoil';
+import { axiosInstance } from '@/api';
 import { tokenStorage } from '@/utils/accessToken';
 
 export const accessTokenAtom = atom<string | null>({
@@ -9,6 +10,7 @@ export const accessTokenAtom = atom<string | null>({
       const token = tokenStorage.get();
       if (token !== null) {
         setSelf(token);
+        axiosInstance.defaults.headers.common['Authorization'] = token;
       }
 
       onSet((token, _, isReset) => {
@@ -16,6 +18,7 @@ export const accessTokenAtom = atom<string | null>({
           tokenStorage.remove();
         } else {
           tokenStorage.set(token);
+          axiosInstance.defaults.headers.common['Authorization'] = token;
         }
       });
     },

--- a/src/components/auth/states/accessTokenAtoms.ts
+++ b/src/components/auth/states/accessTokenAtoms.ts
@@ -1,0 +1,23 @@
+import { atom } from 'recoil';
+import { tokenStorage } from '@/utils/accessToken';
+
+export const accessTokenAtom = atom<string | null>({
+  key: 'accessToken',
+  default: null,
+  effects: [
+    ({ setSelf, onSet }) => {
+      const token = tokenStorage.get();
+      if (token !== null) {
+        setSelf(token);
+      }
+
+      onSet((token, _, isReset) => {
+        if (isReset || token == null) {
+          tokenStorage.remove();
+        } else {
+          tokenStorage.set(token);
+        }
+      });
+    },
+  ],
+});

--- a/src/mocks/fixtures/auth.ts
+++ b/src/mocks/fixtures/auth.ts
@@ -1,4 +1,4 @@
-import type { EmailCheckResponse, EmailCodeCheckResponse, JoinResponse } from '@/api/auth/type';
+import type { EmailCheckResponse, EmailCodeCheckResponse, JoinResponse, LoginResponse } from '@/api/auth/type';
 
 export const emailCheckResponse: EmailCheckResponse = {
   success: true,
@@ -10,20 +10,23 @@ export const emailCheckResponse: EmailCheckResponse = {
 export const emailCodeCheckResponse: EmailCodeCheckResponse = {
   success: true,
   code: 200,
-  message: '인증코드가 불일치합니다.',
+  message: 'ok',
   result: null,
 };
 
 export const joinResponse: JoinResponse = {
   success: true,
   code: 200,
-  message: '인증코드가 불일치합니다.',
+  message: 'ok',
   result: null,
 };
 
 export const loginResponse: LoginResponse = {
   success: true,
   code: 200,
-  message: '인증코드가 불일치합니다.',
-  result: null,
+  message: 'ok',
+  result: {
+    token:
+      'Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJzc2FyQG5hdGUuY29tIiwicm9sZSI6IlJPTEVfVVNFUiIsImlkIjoyLCJleHAiOjE2ODcwNTIzNTd9.v-0C5EoV-QfGVC3Qdis1HLfKf4ZaYIBacWQ5ttkdtTOj6QqVJ4KoyQdvxBUz3NvjC-W0gs7EDFgwzMaaV1vuGg',
+  },
 };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import { RecoilRoot } from 'recoil';
 import type { AppProps } from 'next/app';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
@@ -28,13 +29,15 @@ export default function App({ Component, pageProps }: AppProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <ThemeProvider theme={emotionTheme}>
-        <ToastProvider>
-          <Layout>
-            <Component {...pageProps} />
-          </Layout>
-        </ToastProvider>
-      </ThemeProvider>
+      <RecoilRoot>
+        <ThemeProvider theme={emotionTheme}>
+          <ToastProvider>
+            <Layout>
+              <Component {...pageProps} />
+            </Layout>
+          </ToastProvider>
+        </ThemeProvider>
+      </RecoilRoot>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/src/utils/accessToken.ts
+++ b/src/utils/accessToken.ts
@@ -1,0 +1,11 @@
+export const tokenStorage = {
+  get() {
+    return localStorage.getItem('accessToken');
+  },
+  set(accessToken: string) {
+    localStorage.setItem('accessToken', accessToken);
+  },
+  remove() {
+    localStorage.removeItem('accessToken');
+  },
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7214,6 +7214,11 @@ gunzip-maybe@^1.4.2:
     pumpify "^1.3.3"
     through2 "^2.0.3"
 
+hamt_plus@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/hamt_plus/-/hamt_plus-1.0.2.tgz#e21c252968c7e33b20f6a1b094cd85787a265601"
+  integrity sha512-t2JXKaehnMb9paaYA7J0BX8QQAY8lwfQ9Gjf4pg/mk4krt+cmwmU652HOoWonf+7+EQV97ARPMhhVgU1ra2GhA==
+
 handlebars@^4.7.7:
   version "4.7.8"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.8.tgz#41c42c18b1be2365439188c77c6afae71c0cd9e9"
@@ -9684,6 +9689,13 @@ recast@^0.23.1:
     esprima "~4.0.0"
     source-map "~0.6.1"
     tslib "^2.0.1"
+
+recoil@^0.7.7:
+  version "0.7.7"
+  resolved "https://registry.yarnpkg.com/recoil/-/recoil-0.7.7.tgz#c5f2c843224384c9c09e4a62c060fb4c1454dc8e"
+  integrity sha512-8Og5KPQW9LwC577Vc7Ug2P0vQshkv1y3zG3tSSkWMqkWSwHmE+by06L8JtnGocjW6gcCvfwB3YtrJG6/tWivNQ==
+  dependencies:
+    hamt_plus "1.0.2"
 
 reflect.getprototypeof@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
## 변경사항

- 로그인 시 Access Token을 발급 받아 recoil 전역 상태로 관리함과 동시에 localStorage에 저장한다.
- 모든 API 요청의 Header에 Token을 사용한다.

## 체크리스트

-   [x] Access Token 관리

## 논의하고 싶은점


## Linked Issues

close #64 
