### PR TITLE
feat: 반응형 컴포넌트

### DIFF
--- a/src/components/common/GNB/index.tsx
+++ b/src/components/common/GNB/index.tsx
@@ -13,6 +13,7 @@ import Skeleton from '@/components/common/Skeleton';
 import { tilyLinks } from '@/constants/links';
 import useAuth from '@/hooks/useAuth';
 import { useModalState } from '@/hooks/useModalState';
+import useViewport from '@/hooks/useViewport';
 import * as Styled from './style';
 
 const GNB = () => {
@@ -27,6 +28,7 @@ const GNB = () => {
   const { isOpen: isAlarmOpen, handleClose: handleCloseAlarm, handleToggle: handleToggleAlarm } = useModalState(false);
   const alarmButtonRef = useRef<HTMLButtonElement>(null);
   const router = useRouter();
+  const { isMobile } = useViewport();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -59,9 +61,15 @@ const GNB = () => {
       <Styled.Root isLoggedIn={isLoggedIn} isScrolled={isScrolled}>
         <Styled.Inner>
           <button onClick={() => router.push(tilyLinks.home())}>
-            <Styled.Logo>
-              <Logo imageSize={32} />
-            </Styled.Logo>
+            {isMobile ? (
+              <Styled.Logo>
+                <Logo imageSize={16} />
+              </Styled.Logo>
+            ) : (
+              <Styled.Logo>
+                <Logo imageSize={32} />
+              </Styled.Logo>
+            )}
           </button>
 
           <Styled.NavArea>

--- a/src/components/common/GNB/index.tsx
+++ b/src/components/common/GNB/index.tsx
@@ -9,11 +9,11 @@ import CustomSuspense from '@/components/common/CustomSuspense';
 import Alarm from '@/components/common/GNB/Alarm';
 import TILModal from '@/components/common/GNB/TILModal';
 import Logo from '@/components/common/Logo';
+import Responsive from '@/components/common/Responsive';
 import Skeleton from '@/components/common/Skeleton';
 import { tilyLinks } from '@/constants/links';
 import useAuth from '@/hooks/useAuth';
 import { useModalState } from '@/hooks/useModalState';
-import useViewport from '@/hooks/useViewport';
 import * as Styled from './style';
 
 const GNB = () => {
@@ -28,7 +28,6 @@ const GNB = () => {
   const { isOpen: isAlarmOpen, handleClose: handleCloseAlarm, handleToggle: handleToggleAlarm } = useModalState(false);
   const alarmButtonRef = useRef<HTMLButtonElement>(null);
   const router = useRouter();
-  const { isMobile } = useViewport();
 
   useEffect(() => {
     const handleScroll = () => {
@@ -61,15 +60,17 @@ const GNB = () => {
       <Styled.Root isLoggedIn={isLoggedIn} isScrolled={isScrolled}>
         <Styled.Inner>
           <button onClick={() => router.push(tilyLinks.home())}>
-            {isMobile ? (
+            <Responsive device="mobile">
               <Styled.Logo>
                 <Logo imageSize={16} />
               </Styled.Logo>
-            ) : (
+            </Responsive>
+
+            <Responsive device="desktop">
               <Styled.Logo>
                 <Logo imageSize={32} />
               </Styled.Logo>
-            )}
+            </Responsive>
           </button>
 
           <Styled.NavArea>

--- a/src/components/common/Responsive/index.tsx
+++ b/src/components/common/Responsive/index.tsx
@@ -1,0 +1,50 @@
+import { type PropsWithChildren, useContext, useEffect, useState } from 'react';
+import { ResponsiveContext } from '@/components/common/Responsive/provider';
+import { emotionTheme } from '@/styles/emotion';
+
+interface ResponsiveProps {
+  className?: string;
+  device: Device;
+}
+
+type Device = 'mobile' | 'desktop';
+
+const Responsive = (props: PropsWithChildren<ResponsiveProps>) => {
+  const { className = '', children, device } = props;
+
+  const { mobileOnlyClassName, desktopOnlyClassName } = useContext(ResponsiveContext);
+  const [current, setCurrent] = useState<Device | null>(null);
+
+  const { mediaQuery } = emotionTheme;
+
+  const selectedClassName = (() => {
+    if (device === 'desktop') return desktopOnlyClassName;
+    if (device === 'mobile') return mobileOnlyClassName;
+  })();
+
+  useEffect(() => {
+    const mobileMedia = window.matchMedia(mediaQuery.MOBILE_LARGE);
+
+    if (mobileMedia.matches) {
+      setCurrent('mobile');
+    } else {
+      setCurrent('desktop');
+    }
+
+    const handleChange = (e: MediaQueryListEvent) => {
+      setCurrent(e.matches ? 'mobile' : 'desktop');
+    };
+
+    mobileMedia.addEventListener('change', handleChange);
+
+    return () => mobileMedia.removeEventListener('change', handleChange);
+  }, []);
+
+  return current === null || device === current ? (
+    <div className={`${selectedClassName} ${className}`}>{children}</div>
+  ) : (
+    <></>
+  );
+};
+
+export default Responsive;

--- a/src/components/common/Responsive/provider/index.tsx
+++ b/src/components/common/Responsive/provider/index.tsx
@@ -1,0 +1,48 @@
+import type { PropsWithChildren } from 'react';
+import { createContext } from 'react';
+import { css, Global } from '@emotion/react';
+import { emotionTheme } from '@/styles/emotion';
+
+interface ResponsiveContextValue {
+  mobileOnlyClassName: string;
+  desktopOnlyClassName: string;
+}
+
+export const ResponsiveContext = createContext<ResponsiveContextValue>({} as ResponsiveContextValue);
+
+const ResponsiveProvider = (props: PropsWithChildren) => {
+  const { children } = props;
+  const { mediaQuery } = emotionTheme;
+
+  const mobileOnlyClassName = `responsive-mobile-only`;
+  const desktopOnlyClassName = `responsive-desktop-only`;
+
+  return (
+    <ResponsiveContext.Provider value={{ mobileOnlyClassName, desktopOnlyClassName }}>
+      <Global
+        styles={css`
+          .${mobileOnlyClassName} {
+            display: none !important;
+          }
+
+          .${desktopOnlyClassName} {
+            display: block !important;
+          }
+
+          @media ${mediaQuery.MOBILE_LARGE} {
+            .${mobileOnlyClassName} {
+              display: block !important;
+            }
+
+            .${desktopOnlyClassName} {
+              display: none !important;
+            }
+          }
+        `}
+      />
+      {children}
+    </ResponsiveContext.Provider>
+  );
+};
+
+export default ResponsiveProvider;

--- a/src/hooks/useViewport.ts
+++ b/src/hooks/useViewport.ts
@@ -4,7 +4,8 @@ export interface IsMobile {
   isMobile: boolean;
 }
 
-function useViewport() {
+/** @deprecated @components/common/Responsive를 대신 사용하세요. 모바일에서 초기 접속시 데스크톱 뷰가 잠깐 노출되는 문제가 있어요. */
+const useViewport = () => {
   const [width, setWidth] = useState(0);
   const [height, setHeight] = useState(0);
   const [isMobile, setIsMobile] = useState(false);
@@ -26,6 +27,6 @@ function useViewport() {
     height,
     isMobile,
   };
-}
+};
 
 export default useViewport;

--- a/src/hooks/useViewport.ts
+++ b/src/hooks/useViewport.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+export interface IsMobile {
+  isMobile: boolean;
+}
+
+function useViewport() {
+  const [width, setWidth] = useState(0);
+  const [height, setHeight] = useState(0);
+  const [isMobile, setIsMobile] = useState(false);
+
+  const handleResize = () => {
+    setWidth(window.innerWidth);
+    setHeight(window.innerHeight);
+    setIsMobile(window.innerWidth <= 768 || window.outerWidth <= 768);
+  };
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return {
+    width,
+    height,
+    isMobile,
+  };
+}
+
+export default useViewport;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider, QueryErrorResetBoundary } from '@tans
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ThemeProvider } from '@emotion/react';
 import GlobalErrorBoundary from '@/components/common/GlobalErrorBoundary';
+import ResponsiveProvider from '@/components/common/Responsive/provider';
 import ToastProvider from '@/components/common/Toast/provider';
 import { emotionTheme } from '@/styles/emotion';
 import '@/styles/globals.css';
@@ -46,21 +47,23 @@ export default function App({ Component, pageProps }: AppProps) {
     <QueryClientProvider client={queryClient}>
       <RecoilRoot>
         <ThemeProvider theme={emotionTheme}>
-          <ToastProvider>
-            <QueryErrorResetBoundary>
-              {({ reset }) => (
-                <ErrorBoundary
-                  onReset={reset}
-                  fallbackRender={({ error, resetErrorBoundary }) => {
-                    return <GlobalErrorBoundary error={error} resetErrorBoundary={resetErrorBoundary} />;
-                  }}>
-                  <Layout>
-                    <Component {...pageProps} />
-                  </Layout>
-                </ErrorBoundary>
-              )}
-            </QueryErrorResetBoundary>
-          </ToastProvider>
+          <ResponsiveProvider>
+            <ToastProvider>
+              <QueryErrorResetBoundary>
+                {({ reset }) => (
+                  <ErrorBoundary
+                    onReset={reset}
+                    fallbackRender={({ error, resetErrorBoundary }) => {
+                      return <GlobalErrorBoundary error={error} resetErrorBoundary={resetErrorBoundary} />;
+                    }}>
+                    <Layout>
+                      <Component {...pageProps} />
+                    </Layout>
+                  </ErrorBoundary>
+                )}
+              </QueryErrorResetBoundary>
+            </ToastProvider>
+          </ResponsiveProvider>
         </ThemeProvider>
       </RecoilRoot>
       <ReactQueryDevtools initialIsOpen={false} />

--- a/src/styles/emotion/index.tsx
+++ b/src/styles/emotion/index.tsx
@@ -46,6 +46,18 @@ const layer = {
   toast: 10000,
 };
 
-export const emotionTheme = { colors, layout, layer } as const;
+const DESKTOP_SMALL_WIDTH = 1024;
+const TABLET_WIDTH = 768;
+const MOBILE_LARGE_WIDTH = 425;
+const MOBILE_SMALL_WIDTH = 375;
+
+const mediaQuery = {
+  DESKTOP_SMALL: `screen and (max-width: ${DESKTOP_SMALL_WIDTH}px)`,
+  TABLET: `screen and (max-width: ${TABLET_WIDTH}px)`,
+  MOBILE_LARGE: `screen and (max-width: ${MOBILE_LARGE_WIDTH}px)`,
+  MOBILE_SMALL: `screen and (max-width: ${MOBILE_SMALL_WIDTH}px)`,
+};
+
+export const emotionTheme = { colors, layout, layer, mediaQuery } as const;
 
 export type EmotionTheme = typeof emotionTheme;


### PR DESCRIPTION
## 변경사항

반응형 작업에 사용될 Response 컴포넌트를 만들었어요.
데스크탑에는 보여지지만 모바일 환경에서는 보여지면 안될때, 또는 그 반대의 경우에 사용될 거예요.

### 왜 Response 컴포넌트를 만들어야 했을까요?
Next Image 는 width, height 를 props로 내려주는 방식을 사용하고 있어요. 이 값들을 어떻게 각각의 기기에 맞게 변경해야하지? 라는 고민이 생겼습니다. 
(찾아보니 size 라는 옵션이 있더라구요. 하지만 이는 미디어쿼리에 대응되는 사이즈를 정하는 것이라 같은 스크린 크기에서 다른 이미지 사이즈를 보여줘야하는 경우 (ex 로고 컴포넌트) 에 사용되기에는 적합하지 않다고 생각했어요.)

그래서 처음에 생각해본 해결방법은 useViewport 라는 훅을 하나 만들어서 현재 스크린이 모바일인지 아닌지를 여부를 isMobile 이라는 변수에 리턴하기로 했어요.
하지만 위 훅에서 isMobile 은 useEffect 가 실행될떄 변경이되고 SSR 환경에서는 초기값인 데스크탑 환경 값이 대입되게 됐어요.
즉, 데스크탑 환경의 상태로 pre-render 가 발생했어요.

https://github.com/Step3-kakao-tech-campus/Team7_FE/assets/62373865/3378e3c2-e3b5-4c93-82db-29f4a0727858

유저는 위처럼 데스크탑 환경의 로고를 볼 수 밖에 없었습니다..

### 그럼 이 문제를 어떻게 해결하기위해서
Responsive provider, Responsive 컴포넌트를 만들었어요.

동작원리는 다음과 같아요.
미리 provider 에 모바일 환경, 데스크탑 환경에 대한 CSS 를 emotion global을 사용해서 적용해둡니다.

그리고 Response 컴포넌트를 사용해서 이렇게 모바일, 데스크탑에 대한 UI를 작성해줍니다.

```
            <Responsive device="mobile">
              <Styled.Logo>
                <Logo imageSize={16} />
              </Styled.Logo>
            </Responsive>

            <Responsive device="desktop">
              <Styled.Logo>
                <Logo imageSize={32} />
              </Styled.Logo>
            </Responsive>
```

이렇게 되면 두가지 UI 모두 pre-render에서 DOM에 반영이 되어 있을 겁니다. 하지만 provider에 적용해둔 css 로 인해 유저는 본인의 디바이스에 맞는 UI만 첫렌더링때 보게 됩니다.

그럼 여기서 의문점이 생기실 텐데요. 보여지지 않는 UI는 DOM에 계속 남아 있는걸까? 일 것 같아요.
위 문제는 하이드레이션이 발생하면 Responsive의 useEffect가 동작해서 보여지지 않는(display:none) 상태인 DOM 엘리먼트를 언마운트 시키는 것으로 해결했어요.

### 적용전

https://github.com/Step3-kakao-tech-campus/Team7_FE/assets/62373865/855cd681-0474-4360-a48f-0806cba38fc9


### 적용후

https://github.com/Step3-kakao-tech-campus/Team7_FE/assets/62373865/3b0876f9-4edd-4326-af71-28247b19ef82









