### PR TITLE
fix: 모달 form 엔터 제출 방지

### DIFF
--- a/src/components/roadmap/manage/step/StepModal/index.tsx
+++ b/src/components/roadmap/manage/step/StepModal/index.tsx
@@ -14,6 +14,7 @@ import RadioButton from '@/components/common/RadioButton';
 import TextArea from '@/components/common/TextArea';
 import TwoButtonContainer from '@/components/common/TwoButtonContainer';
 import useQueryParam from '@/hooks/useQueryParam';
+import preventEnterSubmit from '@/utils/preventEnterSubmit';
 
 interface StepModalProps extends ModalProps {
   isEdit?: boolean;
@@ -79,7 +80,7 @@ const StepModal = (props: StepModalProps) => {
           <InfoArea.Info>STEP에는 참고 자료와 동영상 자료를 삽입할 수 있습니다.</InfoArea.Info>
         </InfoArea>
 
-        <FlexForm onSubmit={handleSubmit(onSubmit)}>
+        <FlexForm onSubmit={handleSubmit(onSubmit)} onKeyDown={preventEnterSubmit}>
           <Controller
             name="title"
             control={control}

--- a/src/components/roadmap/manage/step/WebModal/index.tsx
+++ b/src/components/roadmap/manage/step/WebModal/index.tsx
@@ -10,6 +10,7 @@ import Modal, { type ModalProps } from '@/components/common/Modal';
 import TwoButtonContainer from '@/components/common/TwoButtonContainer';
 import REGEX from '@/constants/regex';
 import useQueryParam from '@/hooks/useQueryParam';
+import preventEnterSubmit from '@/utils/preventEnterSubmit';
 
 interface WebModalProps extends ModalProps {
   step: StepWithReferences;
@@ -46,7 +47,7 @@ const WebModal = (props: WebModalProps) => {
         <InfoArea>
           <InfoArea.Info>해당 스텝에 사용할 참고자료 링크를 첨부해주세요.</InfoArea.Info>
         </InfoArea>
-        <FlexForm onSubmit={handleSubmit(onSubmit)}>
+        <FlexForm onSubmit={handleSubmit(onSubmit)} onKeyDown={preventEnterSubmit}>
           <Controller
             name="link"
             control={control}

--- a/src/components/roadmap/manage/step/YoutubeModal/index.tsx
+++ b/src/components/roadmap/manage/step/YoutubeModal/index.tsx
@@ -9,6 +9,7 @@ import Input from '@/components/common/Input';
 import Modal, { type ModalProps } from '@/components/common/Modal';
 import TwoButtonContainer from '@/components/common/TwoButtonContainer';
 import useQueryParam from '@/hooks/useQueryParam';
+import preventEnterSubmit from '@/utils/preventEnterSubmit';
 
 interface YoutubeModalProps extends ModalProps {
   step: StepWithReferences;
@@ -45,7 +46,7 @@ const YoutubeModal = (props: YoutubeModalProps) => {
         <InfoArea>
           <InfoArea.Info>해당 스텝에 사용할 동영상 링크를 첨부해주세요.</InfoArea.Info>
         </InfoArea>
-        <FlexForm onSubmit={handleSubmit(onSubmit)}>
+        <FlexForm onSubmit={handleSubmit(onSubmit)} onKeyDown={preventEnterSubmit}>
           <Controller
             name="link"
             control={control}

--- a/src/utils/preventEnterSubmit.ts
+++ b/src/utils/preventEnterSubmit.ts
@@ -1,0 +1,5 @@
+const preventEnterSubmit = (e: React.KeyboardEvent<HTMLFormElement>) => {
+  if (e.key === 'Enter') e.preventDefault();
+};
+
+export default preventEnterSubmit;


### PR DESCRIPTION
## 변경사항

```typescript
const preventEnterSubmit = (e: React.KeyboardEvent<HTMLFormElement>) => {
  if (e.key === 'Enter') e.preventDefault();
};

export default preventEnterSubmit;
```

유틸 함수를 통해 `form`의 `keyDown` 을 감지한다.

<img width="606" alt="image" src="https://github.com/Step3-kakao-tech-campus/Team7_FE/assets/83194164/f2a0a3ad-631f-4b0f-98ed-4b27dca957b7">


## 체크리스트

-   [x] 모달의 form 엔터 키 제출 방지

## 논의하고 싶은점


## Linked Issues

close #244 
